### PR TITLE
Update es.yml

### DIFF
--- a/languages/es.yml
+++ b/languages/es.yml
@@ -80,7 +80,7 @@ es:
   BUTTON_TRAINING_START: Empezar a entrenar
   BUTTON_TRAINING_STOP: Detener el entrenamiento
   BUTTON_CANCEL_CONTRACT: Cancelar el contrato
-  BUTTON_CANCEL_GAMEPORT: Cancelar el puerto del juego
+  BUTTON_CANCEL_GAMEPORT: Cancelar el port del juego
   BUTTON_CANCEL_FEATURE: Cancelar la funcionalidad
   BUTTON_CANCEL_GAMEENGINE: Cancelar el motor del juego
   BUTTON_CANCEL_GAMEUPDATE: Cancelar la actualización gratuita
@@ -396,7 +396,7 @@ es:
   LABEL_PLATFORM_GAME_EXCLUSIVE_WELCOME: |
     Hola [b]%s[/b],
 
-    Estoy encantado de ver que su estudio publica juegos de calidad. Estoy aquí para hablar de [b]%s[/b], este juego parece prometedor, y me gustaría ayudaros a que su lanzamiento sea un éxito mundial! [b]%s[/b] será presentado, y empaquetaremos tu juego con nuestra consola. A cambio, queremos que este juego sea una exclusiva de [b]%s[/b]. [i](Todos los puertos de las consolas que no sean [b]%s[/b] serán cancelados)[/i]
+    Estoy encantado de ver que su estudio publica juegos de calidad. Estoy aquí para hablar de [b]%s[/b], este juego parece prometedor, y me gustaría ayudaros a que su lanzamiento sea un éxito mundial! [b]%s[/b] será presentado, y empaquetaremos tu juego con nuestra consola. A cambio, queremos que este juego sea una exclusiva de [b]%s[/b]. [i](Todos los ports de las consolas que no sean [b]%s[/b] serán cancelados)[/i]
     Además de mostrar tu juego, te ofrecemos [b]%s$[/b]. ¿Tenemos un trato?
   LABEL_CLOUDS: Mostrar las nubes en el mapa
   LABEL_AUTOSAVE: Guardado Automatico


### PR DESCRIPTION
Nobody translates port when it refers to a video game port, at least in Spain it's common to use the english word to refer to a game being available in a different platform

Like for example in this piece of news https://www.3djuegos.com/noticias-ver/212808/homefront-the-revolution-esconde-un-port-de-timesplitters-2/