### PR TITLE
Fix typo in counter-hacking minigame tutorial

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -271,8 +271,8 @@ en:
   BUTTON_CLICK_ME: Click me
   LABEL_FIREWALL_SIMULATOR_TITLE: Counter-hacking simulator
   LABEL_FIREWALL_SIMULATOR_DESCRIPTION: |
-    Your objective, protect your game, otherwise it's get hacked.
-    To achieve that objective, click on the blue buttons so they reach 0 to protect the network.
+    Your objective, protect your game, otherwise it will be hacked.
+    To achieve that objective, click on the blue buttons until they reach 0 to protect the network.
 
     It is simple, but you gotta go fast!
   LABEL_GAME_UPDATE_NB: Number of updates


### PR DESCRIPTION
"otherwise it's get hacked" => "otherwise it will be hacked"
"click on the blue buttons so they reach 0" => "click on the blue buttons until they reach 0" (not a typo, but the latter feels much more natural, might be overstepping my bounds here regardless?) 

Noticed the typo as I was doing my first legit vanilla run in a long while