### PR TITLE
Fix a typo in LABEL_BURNING_SERVER_TITLE for EN

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -1631,7 +1631,7 @@ en:
     Does it smell like fire?!
     Your servers have reached their maximum capacity.
     It is time to buy new servers or to close an online game!
-  LABEL_BURNING_SERVER_TITLE: This is fine
+  LABEL_BURNING_SERVER_TITLE: This is fire
   LABEL_SMOKING_SERVER_DESCRIPTION: |
     You are making very good online game, and you are selling them very well.
     However your servers are reaching their maximum capacity, most of them are used at 90%% or more.


### PR DESCRIPTION
I think it is a typo error, the letter `n` and `r` similar, but the meaning of the sentence is different ;)