### PR TITLE
Fix a typo in NEW_ACHIEVEMENT_11_27_NAME for EN

### DIFF
--- a/achievements/en.yml
+++ b/achievements/en.yml
@@ -236,7 +236,7 @@ en:
   NEW_ACHIEVEMENT_11_26_DESC: >
     Release 1000 games
   NEW_ACHIEVEMENT_11_27_NAME: >
-    What''s up Doc?
+    What's up Doc?
   NEW_ACHIEVEMENT_11_27_DESC: >
     Create a postmortem for one game
   NEW_ACHIEVEMENT_11_28_NAME: >


### PR DESCRIPTION
One mark too many... ie. `'`