### PR TITLE
Grammar corrections for english localization

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -661,7 +661,7 @@ en:
   LABEL_PLATFORM_NAME: "Platform's name"
   LABEL_TRADE_PUBLISH_TOOLTIP: |
     This publishing offer is backed by a $%s grant.
-    A %s$ penality applies if you do not achieve a minimum score of %d%%.
+    A %s$ penalty applies if you do not achieve a minimum score of %d%%.
   LABEL_CANNOT_HIRE_NO_DESK: |
     You must have a desk available to hire a specialist.
   LABEL_CUSTOM_CONSOLE: Console development
@@ -1393,7 +1393,7 @@ en:
   LABEL_AUTO_ASSIGN_STAFF: Auto-assign employees
   LABEL_UPGRADE_COMPUTER: Auto-upgrade computers
   LABEL_UPGRADE_SERVER: Auto-upgrade servers
-  LABEL_COMPANY_WIDE: Company wide
+  LABEL_COMPANY_WIDE: Company-wide
   LABEL_STUDIO_WIDE: This studio
   LABEL_NO_STUDIO_TRADE_CAPABLE: >
     You must have at least 5 employees to deal with a publisher.
@@ -1402,7 +1402,7 @@ en:
     For [b]%s[/b] (%s),
 
     We are particularly disappointed that you have cancelled the development of [b]%s[/b].
-    In accordance with the contract duly signed, page 453, paragraph 72d, paragraph W, pink sheet, you must pay the penality of [b]%s$[/b] immediately.
+    In accordance with the contract duly signed, page 453, paragraph 72d, paragraph W, pink sheet, you must pay the penalty of [b]%s$[/b] immediately.
 
     Respectfully,
     The honest law firm, [b]%s[/b]
@@ -1411,13 +1411,13 @@ en:
     For [b]%s[/b] (%s),
 
     [b]%s[/b] has not met with the expected success, and we have to apply the signed contract literally.
-    Thus, according to page 5863, paragraph 99z, brown sheet, you must pay the penality of [b]%s$[/b] immediately.
+    Thus, according to page 5863, paragraph 99z, brown sheet, you must pay the penalty of [b]%s$[/b] immediately.
 
     Respectfully,
     The department of bad sales, [b]%s[/b]
   LABEL_SELECT_GAME_PRESENT: Select the video games to show
   LABEL_ROYALTIES: Royalties
-  LABEL_PENALITY: Penality
+  LABEL_PENALITY: Penalty
   LABEL_NOTE_MIN: Score min.
   LABEL_MARKETING_GLOBAL_ITEM: Marketing overall
   LABEL_MARKETING_MAGAZINE_ITEM: Magazine
@@ -1427,7 +1427,7 @@ en:
   LABEL_MARKETING_BILLBOARD_ITEM: Advertising billboard
   LABEL_MARKETING_SOCIALNETWORK_ITEM: Social networks
   LABEL_MARKETING_MAILINGLIST_ITEM: Newsletter
-  LABEL_SELF_PUBLISH: Self publishing
+  LABEL_SELF_PUBLISH: Self-publishing
   LABEL_TRADE_PUBLISH: Traditional publishing
   LABEL_HIRE_PERFECT_EMPLOYEE_DESCRIPTION: |
     Hello,
@@ -2189,7 +2189,7 @@ en:
 
   # Tutoriel labels
   TOOLTIP_BONUS_HYPE: |
-    It's when you show off your games at conventions that you generate the bonus hype.
+    Bonus hype is generated when showing off your game at conventions.
   TOOLTIP_CUSTOM_PLATFORM_RELEASE: |
     Congratulations, you've just developed your console!
 


### PR DESCRIPTION
Minor grammar corrections for the english localization:
- Changed all instances of "Penality" to "Penalty", (Penality is not correct English)
- Reworked the bonus hype tooltip, the sentence was awkwardly formulated
- Changed "Company wide" and "Self publishing" to "Company-wide" and "Self-publishing", the lack of a hyphen was grammatically incorrect